### PR TITLE
Fix broken README import example and add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # dbt-select-builder
 
+[![PyPI version](https://img.shields.io/pypi/v/dbt-select-builder)](https://pypi.org/project/dbt-select-builder/)
+[![Python versions](https://img.shields.io/pypi/pyversions/dbt-select-builder)](https://pypi.org/project/dbt-select-builder/)
+[![Python Tests](https://github.com/HirofumiTsuda/dbt-select-builder/actions/workflows/python_test.yml/badge.svg)](https://github.com/HirofumiTsuda/dbt-select-builder/actions/workflows/python_test.yml)
+[![License: MIT](https://img.shields.io/github/license/HirofumiTsuda/dbt-select-builder)](LICENSE)
+
 ## What is this repository?
 
 A builder to help you create a select / exclude clause for dbt.
@@ -29,7 +34,7 @@ pip install dbt-select-builder
 Using this library, the following can be written in python code in a straightforward way.
 
 ```python
-from dbt-select-builder import (
+from dbt_select_builder import (
     dbt_and,
     dbt_or
 )
@@ -46,7 +51,7 @@ dbt_and(
 Also, strings with `','` and `' '` are supported.
 
 ```python
-from dbt-select-builder import (
+from dbt_select_builder import (
     dbt_and,
     dbt_or
 )


### PR DESCRIPTION
## What

- Fix the README's quick-start code examples, which imported `from dbt-select-builder` (hyphen) — not a valid Python identifier, so copy-pasting it raises a `SyntaxError`. Changed to the real package name, `dbt_select_builder` (underscore).
- Add PyPI version, Python versions, CI, and License badges to the README header.

## Why

The hyphen/underscore mismatch means anyone following the README's own usage example hits a syntax error on the very first line, before they've had a chance to try the library. Badges make version/build/license status visible without digging into the repo.

## QA

Ran the corrected example against the actual package (`PYTHONPATH=src python -c ...`) and confirmed both snippets produce exactly the output shown in their comments (`"A,C A,D"` and `"A,B,C A,B,D"`). Verified all badge URLs resolve with HTTP 200.