### PR TITLE
Bump to 0.1.1, add PyPI classifiers, fix misleading 3.9 CI entry

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,7 +2,7 @@ name: "Setup"
 description: "Setup environment for dbt-select-builder"
 inputs:
   python-version:
-    default: "3.9"
+    default: "3.10"
     required: false
 
 runs:

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Check out the repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dbt-select-builder"
 version = "0.1.1"
-description = "Add your description here"
+description = "A builder for dbt select/exclude clauses, letting you compose them from AND/OR expressions instead of hand-expanding parentheses yourself."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,18 @@
 [project]
 name = "dbt-select-builder"
-version = "0.1.0"
+version = "0.1.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"
+license = "MIT"
 dependencies = []
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "dbt-select-builder"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

- Bump version to `0.1.1`.
- Add `classifiers` (Python 3.10/3.11/3.12, OS Independent) to `pyproject.toml`.
- Switch the deprecated `License :: OSI Approved :: MIT License` classifier for the SPDX `license = "MIT"` field setuptools now recommends.
- Drop `"3.9"` from the CI test matrix and change the setup action's default `python-version` from `3.9` to `3.10`.

## Why

The package published on PyPI currently has zero classifiers, so shields.io's Python-versions badge shows "missing" instead of real data.

While investigating, found the CI matrix's `"3.9"` entry was misleading: `requires-python = ">=3.10"` makes `uv sync` silently resolve to a 3.10 interpreter no matter what `actions/setup-python` installs, so that job has never actually run on 3.9 (confirmed via the job log: `actions/setup-python` installs 3.9.25, then `uv sync` logs "Using CPython 3.10.20"). Separately, `src/dbt_select_builder/helper.py` uses `X | Y` unions at module scope (not just in type annotations), which isn't valid on 3.9 without further code changes. Decided to keep the existing `>=3.10` floor and fix the CI matrix to match reality, rather than take on 3.9 support.

## QA

- `uv run pytest src/`, `uv run mypy src/`, `uv run ruff check src/` all pass locally.
- `uv build` succeeds with no deprecation warnings (previously warned about the license classifier).
- Verified the built wheel's METADATA has `Version: 0.1.1` and the expected `Classifier:` lines.

## Ref

None