### PR TITLE
Add PyPI publish workflow via Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+
+      - name: Build package
+        run: uv build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    if: github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## What

Add `.github/workflows/publish.yml`:
- Builds the package with `uv build`.
- `push` of a `v*.*.*` tag → publishes to the real PyPI (`environment: pypi`).
- `workflow_dispatch` → publishes to TestPyPI (`environment: testpypi`), for a one-off dry run.

Both publish jobs use `pypa/gh-action-pypi-publish` with OIDC (`permissions: id-token: write`) — no stored PyPI token.

## Why

Currently there's no automated release path; publishing has been manual (`twine upload` with a locally-stored token, per `~/.pypirc`). Trusted Publishing avoids storing a long-lived token as a GitHub secret at all. Since a real PyPI publish can't be undone (a version number can never be reused), this adds a TestPyPI dry-run path to validate the OIDC/Trusted Publisher wiring before it's ever used for a real release.

## QA

Validated the workflow YAML with `python3 -c "import yaml; yaml.safe_load(...)"`. Can't fully exercise this until the setup below is in place.

## Manual setup still needed (not something this PR can do on its own)

1. In this repo's Settings → Environments, create two environments named exactly `pypi` and `testpypi`. Consider adding a required reviewer on `pypi` as a manual approval gate before a real release goes out.
2. On [pypi.org](https://pypi.org/manage/project/dbt-select-builder/settings/publishing/) and [test.pypi.org](https://test.pypi.org/manage/project/dbt-select-builder/settings/publishing/), add a Trusted Publisher for this repo: owner `HirofumiTsuda`, repo `dbt-select-builder`, workflow `publish.yml`, environment name `pypi` (pypi.org) / `testpypi` (test.pypi.org) respectively.

## Ref

None