### PR TITLE
Add PyPI keywords and bump to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [project]
 name = "dbt-select-builder"
-version = "0.1.1"
+version = "0.1.2"
 description = "A builder for dbt select/exclude clauses, letting you compose them from AND/OR expressions instead of hand-expanding parentheses yourself."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
+keywords = ["dbt", "dbt-core", "data-engineering", "select", "selector"]
 dependencies = []
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "dbt-select-builder"
-version = "0.1.1"
+version = "0.1.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Add `keywords = ["dbt", "dbt-core", "data-engineering", "select", "selector"]` to `pyproject.toml`, bump to `0.1.2`.

## Why

PyPI's own search factors in a project's keywords, which were unset. Bumping the version because PyPI metadata is a per-release snapshot (same reason 0.1.1 was needed for classifiers to show up) — keywords won't appear on PyPI until published as a new release.

## QA

`uv run pytest src/`, `uv run mypy src/`, `uv run ruff check src/` all pass locally.

## Ref

None